### PR TITLE
Allow subclasses of HTML::Lint to be used with Test::HTML::Lint

### DIFF
--- a/lib/Test/HTML/Lint.pm
+++ b/lib/Test/HTML/Lint.pm
@@ -87,7 +87,7 @@ will clear its errors before using it.
 sub html_ok {
     my $lint;
 
-    if ( ref($_[0]) eq 'HTML::Lint' ) {
+    if ( ref($_[0]) && $_[0]->isa('HTML::Lint') ) {
         $lint = shift;
         $lint->newfile();
         $lint->clear_errors();


### PR DESCRIPTION
Currently, you can only pass exactly an HTML::Lint object into html_ok.
This commit allows subclasses of HTML::Lint to work as well.
