### PR TITLE
Add support for HTML::Lint::Pluggable

### DIFF
--- a/lib/Test/HTML/Lint.pm
+++ b/lib/Test/HTML/Lint.pm
@@ -87,7 +87,7 @@ will clear its errors before using it.
 sub html_ok {
     my $lint;
 
-    if ( ref($_[0]) eq 'HTML::Lint' ) {
+    if ( ref($_[0]) eq 'HTML::Lint' || ref($_[0]) =~ /HTML::Lint::Pluggable/ ) {
         $lint = shift;
         $lint->newfile();
         $lint->clear_errors();


### PR DESCRIPTION
Test::HTML::Lint currently only supports a $lint object reference of type HTML::Lint, which prevents use of HTML::Lint::Pluggable modules in tests. I needed HTML5 support, so I did some digging, and found why it didn't work. This change allows tests using the HTML4 validator to continue to work, as before, but now makes it possible to add new validators via the pluggable interface.

Using it looks exactly the same, except for setting up the $lint object:

```
    use HTML::Lint::Pluggable;
    my $lint = new HTML::Lint::Pluggable;
    $lint->load_plugins(qw/HTML5/);

    html_ok( $lint, $content, "HTML validation");
```
