### PR TITLE
Perlcritic fixes

### DIFF
--- a/lib/HTML/Lint/Parser.pm
+++ b/lib/HTML/Lint/Parser.pm
@@ -284,7 +284,7 @@ sub _normalize_value {
     $what = _trim( $what );
     return 1 if $what =~ /^(?:1|on|true)$/;
     return 0 if $what =~ /^(?:0|off|false)$/;
-    return undef;
+    return;
 }
 
 sub _trim {

--- a/perlcriticrc
+++ b/perlcriticrc
@@ -16,8 +16,6 @@ allow_leading_tabs = 0
 [-InputOutput::RequireCheckedSyscalls]
 functions = open opendir read readline readdir close closedir
 
-[-Miscellanea::RequireRcsKeywords]
-
 [-Modules::RequireVersionVar]
 
 [-RegularExpressions::RequireDotMatchAnything]


### PR DESCRIPTION
Two tiny changes in order to placate perlcritic:
- Remove explicit disabling of `RequireRcsKeywords` policy in `perlcriticrc`, since it is deprecated anyway now.
- `return` rather than `return undef` in `_normalize_value`: see PBP, p. 199.
