### PR TITLE
Add test for missing alt text on <input type="img">

### DIFF
--- a/t/12-html_fragment_ok.t
+++ b/t/12-html_fragment_ok.t
@@ -7,9 +7,10 @@ require 't/LintTest.pl';
 
 checkit( [
     [ 'elem-img-alt-missing' => 'Set #1 (4:5) <img src="alpha.jpg"> does not have ALT text defined' ],
-    [ 'doc-tag-required'     => 'Set #1 (6:1) <head> tag is required' ],
-    [ 'doc-tag-required'     => 'Set #1 (6:1) <html> tag is required' ],
-    [ 'doc-tag-required'     => 'Set #1 (6:1) <title> tag is required' ],
+    [ 'elem-input-alt-missing' => 'Set #1 (5:5) <input name="" type="image"> does not have non-blank ALT text defined' ],    
+    [ 'doc-tag-required'     => 'Set #1 (7:1) <head> tag is required' ],
+    [ 'doc-tag-required'     => 'Set #1 (7:1) <html> tag is required' ],
+    [ 'doc-tag-required'     => 'Set #1 (7:1) <title> tag is required' ],
 ], [<DATA>] );
 
 __DATA__
@@ -17,5 +18,6 @@ __DATA__
 <p>
     This is a valid fragment, but an incomplete document.
     <img src="alpha.jpg" height="21" width="12">
+    <input type="image">
 </p>
 </body>


### PR DESCRIPTION
Investigation for https://github.com/petdance/html-lint/issues/38.
This test would suggest that the code already identifies missing
alt tag on a img type input.

Further I ran weblint and this showed correct behavior also: Suggest this test proves that issue 38 could be closed.

---

```
$ cat lwtest.html 
<body>
<p>
    <input type="image">
</p>
</body>

$ weblint lwtest.html
lwtest.html (3:5) <input name="" type="image"> does not have non-blank ALT text defined
lwtest.html (5:1) <html> tag is required
lwtest.html (5:1) <head> tag is required
lwtest.html (5:1) <title> tag is required
```

p.s. Started looking at this as part of the CPAN PRC.
