### PR TITLE
perl-5.26.0-readiness.  Account for removal of '.' from default @INC.

### DIFF
--- a/t/40-where.t
+++ b/t/40-where.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 my $html = '</body>';
 

--- a/t/50-multiple-files.t
+++ b/t/50-multiple-files.t
@@ -1,7 +1,7 @@
 use warnings;
 use strict;
 
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 my @files = get_paragraphed_files();
 

--- a/t/60-add-tags.t
+++ b/t/60-add-tags.t
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 use HTML::Lint::HTML4;
 

--- a/t/attr-invalid-entity.t
+++ b/t/attr-invalid-entity.t
@@ -2,7 +2,7 @@
 
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'attr-invalid-entity' => qr/Entity &#8675309; is invalid/i ],

--- a/t/attr-repeated.t
+++ b/t/attr-repeated.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'attr-repeated' => qr/ALIGN attribute in <P> is repeated/i ],

--- a/t/attr-unclosed-entity.t
+++ b/t/attr-unclosed-entity.t
@@ -2,7 +2,7 @@
 
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'attr-unclosed-entity' => qr/Entity &#63; is missing its closing semicolon/ ],

--- a/t/attr-unknown-entity.t
+++ b/t/attr-unknown-entity.t
@@ -2,7 +2,7 @@
 
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'attr-unknown-entity' => qr/Entity &numsefisk; is unknown/ ],

--- a/t/attr-unknown.t
+++ b/t/attr-unknown.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'attr-unknown' => qr/Unknown attribute "FOOD" for tag <P>/i ],

--- a/t/attr-use-entity.t
+++ b/t/attr-use-entity.t
@@ -2,7 +2,7 @@
 
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'attr-use-entity'      => qr/Character "\\xF1" should be written as &ntilde;/ ],

--- a/t/config-unknown-directive.t
+++ b/t/config-unknown-directive.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     # [ 'config-unknown-directive' => q{Set #1 (6:5) Unknown directive "bongo"} ],

--- a/t/config-unknown-value.t
+++ b/t/config-unknown-value.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'config-unknown-value' => qr/Unknown value "14" for elem-img-sizes-missing directive$/ ],

--- a/t/doc-tag-required.t
+++ b/t/doc-tag-required.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'doc-tag-required' => qr/<html> tag is required/ ],

--- a/t/elem-empty-but-closed.t
+++ b/t/elem-empty-but-closed.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'elem-empty-but-closed' => qr/<hr> is not a container -- <\/hr> is not allowed/ ],

--- a/t/elem-img-alt-missing.t
+++ b/t/elem-img-alt-missing.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'elem-img-alt-missing' => qr/<IMG SRC="whizbang\.jpg"> does not have ALT text defined/i ],

--- a/t/elem-img-sizes-missing.t
+++ b/t/elem-img-sizes-missing.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'elem-img-sizes-missing' => qr/\Q<IMG SRC="swedish-schwern.jpg"> tag has no HEIGHT and WIDTH attributes/i ],

--- a/t/elem-input-alt-missing.t
+++ b/t/elem-input-alt-missing.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'elem-input-alt-missing' => qr/<input name="dave" type="image"> does not have non-blank ALT text defined/i ],

--- a/t/elem-nonrepeatable.t
+++ b/t/elem-nonrepeatable.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'elem-nonrepeatable' => qr/<title> is not repeatable, but already appeared at \(3:2\)/i ],

--- a/t/elem-unclosed.t
+++ b/t/elem-unclosed.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'elem-unclosed' => qr/\Q<b> at (6:5) is never closed/i ],

--- a/t/elem-unknown.t
+++ b/t/elem-unknown.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'elem-unknown' => qr/unknown element <donky>/i ],

--- a/t/elem-unopened.t
+++ b/t/elem-unopened.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'elem-unopened' => qr/<\/p> with no opening <P>/i ],

--- a/t/embed-extensions.t
+++ b/t/embed-extensions.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
 ], [<DATA>] );

--- a/t/nolint.t
+++ b/t/nolint.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'elem-img-sizes-missing' => qr/\Q<img src="alpha.jpg"> tag has no HEIGHT and WIDTH attributes/i ],

--- a/t/random-nobr.t
+++ b/t/random-nobr.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'elem-unknown' => qr/unknown element <donky>/i ],

--- a/t/strong-id.t
+++ b/t/strong-id.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'attr-unknown' => qr/Unknown attribute "bongo" for tag <strong>/ ],

--- a/t/text-invalid-entity.t
+++ b/t/text-invalid-entity.t
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'text-unknown-entity' => qr/Entity &metalhorns; is unknown/ ],

--- a/t/text-unclosed-entity.t
+++ b/t/text-unclosed-entity.t
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'text-unclosed-entity' => qr/Entity &ouml; is missing its closing semicolon/ ],

--- a/t/text-unknown-entity.t
+++ b/t/text-unknown-entity.t
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'text-unknown-entity' => qr/Entity &metalhorns; is unknown/ ],

--- a/t/text-use-entity.t
+++ b/t/text-use-entity.t
@@ -1,7 +1,7 @@
 use utf8;
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
     [ 'text-use-entity'      => qr/Character "\\x0B" should be written as &#11;/ ],

--- a/t/xhtml-html.t
+++ b/t/xhtml-html.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-require 't/LintTest.pl';
+require './t/LintTest.pl';
 
 checkit( [
 ], [<DATA>] );


### PR DESCRIPTION
For: https://github.com/petdance/html-lint/issues/55