### PR TITLE
Check for filename of "-", read stdin

### DIFF
--- a/bin/weblint
+++ b/bin/weblint
@@ -56,6 +56,9 @@ for my $url ( @ARGV ) {
             next;
         }
     }
+    elsif ($url eq '-') {
+	@lines = <STDIN>;
+    }
     else {
         open( my $fh, '<', $url ) or die "Can't open $url: $!";
         @lines = <$fh>;


### PR DESCRIPTION
Since three-argument `open()` doesn't automatically handle "-" as a special filename, check for it explicitly and automatically read from `<STDIN>` instead of opening a file.

Fixes: #65 