### PR TITLE
Windows support: unlink file after it has been closed

### DIFF
--- a/t/parse_file.t
+++ b/t/parse_file.t
@@ -7,7 +7,7 @@ use Test::More tests => 1;
 use HTML::Lint;
 use File::Temp qw( tempfile );
 
-my ($o, $OUTPUT_FN) = tempfile( SUFFIX => '.xhtml', UNLINK => 1);
+my ($o, $OUTPUT_FN) = tempfile( SUFFIX => '.xhtml', UNLINK => 0);
 print {$o} <<'EOF';
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
@@ -29,3 +29,5 @@ my $lint = HTML::Lint->new;
 $lint->parse_file($OUTPUT_FN);
 
 is_deeply( [map { $_->as_string() } $lint->errors()], [], 'HTML is valid for output file.' );
+
+unlink($OUTPUT_FN);


### PR DESCRIPTION
Otherwise install on Windows will fail with:

```
    t/parse_file.t .................. Error in tempfile() using template \XXXXXXXXXX.xhtml: Could not create temp file \WzBMoEw1MY.xhtml: Permission denied at t/parse_file.t line 10.
    # Looks like your test exited with 13 before it could output anything.
    t/parse_file.t .................. Dubious, test returned 13 (wstat 3328, 0xd00)
```